### PR TITLE
Fix command `title`

### DIFF
--- a/vscode/extension.py
+++ b/vscode/extension.py
@@ -251,7 +251,7 @@ class Command:
         """
 
         self.name = snake_case_to_camel_case(name)
-        self.title = snake_case_to_title_case(name)
+        self.title = snake_case_to_title_case(title)
         self.ext = ext
 
         if not asyncio.iscoroutinefunction(func):

--- a/vscode/extension.py
+++ b/vscode/extension.py
@@ -251,7 +251,7 @@ class Command:
         """
 
         self.name = snake_case_to_camel_case(name)
-        self.title = snake_case_to_title_case(title)
+        self.title = snake_case_to_title_case(title or name)
         self.ext = ext
 
         if not asyncio.iscoroutinefunction(func):


### PR DESCRIPTION
Hi there!
Very cool project, thank you @CodeWithSwastik 🙇
I managed to create a basic VSCode extension very quickly.

Allow me to propose this simple PR to fix the command `title`.
It was using `name` instead of `title`.